### PR TITLE
[java] update master table locations cache  

### DIFF
--- a/java/kudu-client/src/main/java/org/apache/kudu/client/ConnectToClusterResponse.java
+++ b/java/kudu-client/src/main/java/org/apache/kudu/client/ConnectToClusterResponse.java
@@ -34,6 +34,12 @@ class ConnectToClusterResponse {
   private static final ByteString FAKE_TABLET_ID = ByteString.copyFromUtf8(
       AsyncKuduClient.MASTER_TABLE_NAME_PLACEHOLDER);
 
+  /**
+   * If the client caches master locations, the entries should not live longer
+   * than this timeout. Defaults to one hour.
+   */
+  private static final int CACHE_TTL_MS = 60 * 60 * 1000;
+
   /** The host and port of the master that is currently leader */
   private final HostAndPort leaderHostAndPort;
   /** The response from that master */
@@ -73,6 +79,7 @@ class ConnectToClusterResponse {
         .addTsInfos(TSInfoPB.newBuilder()
             .addRpcAddresses(ProtobufHelper.hostAndPortToPB(leaderHostAndPort))
             .setPermanentUuid(ByteString.copyFromUtf8(fakeUuid)))
+        .setTtlMillis(CACHE_TTL_MS)
         .build();
   }
 }

--- a/src/kudu/master/master.proto
+++ b/src/kudu/master/master.proto
@@ -692,7 +692,7 @@ message GetTableLocationsResponsePB {
 
   // If the client caches table locations, the entries should not live longer
   // than this timeout. Defaults to one hour.
-  optional uint32 ttl_millis = 3 [default = 36000000];
+  optional uint32 ttl_millis = 3 [default = 3600000];
 }
 
 message AlterTableRequestPB {


### PR DESCRIPTION
Recently a master in our cluster is down because of network issues and somehow the server didn't close the connections to some clients. Then these clients keep trying to connect to the dead master but can't receive response until timeout, even when this server is up the client still send rpc through the old channel and can't connect to the server and the new leader master. The only solution is to restart clients.

This patch fixes the issue that java client can't invalidate stale locations of the leader master. Maybe in this case we also need a better way to trigger connection shutdown for an inactive channel.