### PR TITLE
KUDU-3384: Handling IncrementEncodedKey failure

### DIFF
--- a/src/kudu/client/flex_partitioning_client-test.cc
+++ b/src/kudu/client/flex_partitioning_client-test.cc
@@ -1970,9 +1970,7 @@ class FlexPartitioningScanTest : public FlexPartitioningTest {
 };
 
 // This scenario is to reproduce the issue described in KUDU-3384.
-//
-// TODO(aserbin): enable the scenario once KUDU-3384 is fixed
-TEST_F(FlexPartitioningScanTest, DISABLED_MaxKeyValue) {
+TEST_F(FlexPartitioningScanTest, MaxKeyValue) {
   static constexpr const char* const kTableName = "max_key_value";
 
   unique_ptr<KuduTableCreator> table_creator(client_->NewTableCreator());


### PR DESCRIPTION
While using lower/upper of a DRS to optimize scan at DRS level, we
should handle the cases where a upper bound key cannot be incremented.
This patch fixes it, enables the reproduction scenario and also adds
a regression test.

Change-Id: I22c48f9893364c3fad5597431e4acfbcb2a4b43d