### PR TITLE
[thirdparty] disable nghttp2 feature in libcurl

### DIFF
--- a/thirdparty/build-definitions.sh
+++ b/thirdparty/build-definitions.sh
@@ -762,6 +762,7 @@ build_curl() {
     --without-libpsl \
     --without-librtmp \
     --without-libssh2 \
+    --without-nghttp2 \
     --with-gssapi
   unset KRB5CONFIG
   make -j$PARALLEL $EXTRA_MAKEFLAGS install


### PR DESCRIPTION
To avoid some linking errors